### PR TITLE
update plugins to match 1.6.0-RC13

### DIFF
--- a/charts/backstage/templates/_partials.tpl
+++ b/charts/backstage/templates/_partials.tpl
@@ -42,17 +42,17 @@ plugins:
 
 {{- define "orchestrator.plugins.config" }}
 orchestratorPlugins: 
-    scope: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.11"
+    scope: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.13"
     orchestrator:
-      package: "backstage-plugin-orchestrator-1.6.0-rc.11.tgz"
-      integrity: sha512-jZNnWMh4Hjs9cem5uvmt89j3Yded61EVYk/NbzeqPfW9NFP7oOzNwyfQeG59hsNQ/PEiL7XIEzGp0vIHbHL+Cg==
+      package: "backstage-plugin-orchestrator-1.6.0-rc.13.tgz"
+      integrity: sha512-8hG2rviqBzzEVRhbHdyZxRZBPLV2fbsDhmTqZSbB6Yt9fDvKNZ/WIaoDGcMmv4cUcmfI3ozTdd5935/1RJG/nA==
     orchestratorBackend:
-      package: "backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.11.tgz"
-      integrity: sha512-ebw1Uk5xsRzIfMziZ4sZU6UPxfQcHnEqAldAGDxT1vih5t+S/w1LuGlRGhajk3JXeA+RUXA6xfFcr9nNgYGegQ==
+      package: "backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.13.tgz"
+      integrity: sha512-bnfDpTa3snJMByumIGOSt0iuT0kQEAA7w9lLY1SrLm++3maWFUw6zAe70DQsT7qv1d+gx6pXCdmyTAxk8L+4dw==
     scaffolderBackendOrchestrator:
-      package: "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.11.tgz"
-      integrity: sha512-ufHBFH1maL4w9/pxweFFzK2pGbhDfbJwSfPKmQyCtilJRUR7bLSPKXP2ZYYrR8tysiQ0vB6fw2FtuNQNDqHtqQ==
+      package: "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.13.tgz"
+      integrity: sha512-2ocAxZYxsymLzVNe2ebiD1b9/TxJZyh7TYDcM6PeC1G416Mqf8QJZMuHh44hfBpdDkRRK8qRrVEDOAfDC2J5sA==
     orchestratorFormWidgets:
-      package: "backstage-plugin-orchestrator-form-widgets-1.6.0-rc.11.tgz"
-      integrity: sha512-cZwpaHA1MoydTxRU3404AqgjzX+IeW1/2jnqzSHn4XwYNAg5xk5udTSq+zVabmimdeeKXWB3iCWi1sP4bLkdKQ==
+      package: "backstage-plugin-orchestrator-form-widgets-1.6.0-rc.13.tgz"
+      integrity: sha512-F49J8XOql9TPlETzqy5ll0XHM4HZiWQbEzM8RsOdMTaMh6FNoTR04LATFDYTi/gQg4PC5qT8W7wSxH7gH/Gj3w==
 {{- end }}


### PR DESCRIPTION
According to https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/tag/v1.6.0-rc.13