### PR TITLE
Updating plugins to RC-1.6.14

### DIFF
--- a/charts/backstage/templates/_partials.tpl
+++ b/charts/backstage/templates/_partials.tpl
@@ -42,17 +42,17 @@ plugins:
 
 {{- define "orchestrator.plugins.config" }}
 orchestratorPlugins: 
-    scope: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.13"
+    scope: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.14"
     orchestrator:
-      package: "backstage-plugin-orchestrator-1.6.0-rc.13.tgz"
-      integrity: sha512-8hG2rviqBzzEVRhbHdyZxRZBPLV2fbsDhmTqZSbB6Yt9fDvKNZ/WIaoDGcMmv4cUcmfI3ozTdd5935/1RJG/nA==
+      package: "backstage-plugin-orchestrator-1.6.0-rc.14.tgz"
+      integrity: sha512-9gmptRRqrx0cZjThctJJLYCuzPa1av5S9NdAitAFsGvx5KVgVK8VinOKpyHgLbM6cdBDdIne0wdVFaLijxQHjg==
     orchestratorBackend:
-      package: "backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.13.tgz"
-      integrity: sha512-bnfDpTa3snJMByumIGOSt0iuT0kQEAA7w9lLY1SrLm++3maWFUw6zAe70DQsT7qv1d+gx6pXCdmyTAxk8L+4dw==
+      package: "backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.14.tgz"
+      integrity: sha512-kuN16JcbbPSvBdr0iJRUlwMaXppTir+edpsYQerXzHsZhaU9cEzXEI5tAsUklOb5qSAi9ENeCZTK0jTlp8wUlg==
     scaffolderBackendOrchestrator:
-      package: "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.13.tgz"
-      integrity: sha512-2ocAxZYxsymLzVNe2ebiD1b9/TxJZyh7TYDcM6PeC1G416Mqf8QJZMuHh44hfBpdDkRRK8qRrVEDOAfDC2J5sA==
+      package: "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.14.tgz"
+      integrity: sha512-HpP6WFu8xTc2HTg2QLLRCW59nyt4MhFhlww477BUcBwiHzohJipG30b3eT/OcSMaFIMgOaD2dCMlLfxWLab9Qg==
     orchestratorFormWidgets:
-      package: "backstage-plugin-orchestrator-form-widgets-1.6.0-rc.13.tgz"
-      integrity: sha512-F49J8XOql9TPlETzqy5ll0XHM4HZiWQbEzM8RsOdMTaMh6FNoTR04LATFDYTi/gQg4PC5qT8W7wSxH7gH/Gj3w==
+      package: "backstage-plugin-orchestrator-form-widgets-1.6.0-rc.14.tgz"
+      integrity: sha512-ZQwbHD7wWQ9ElOetThPLBwbcmpNR8A+S+XLtG9Q2c7EycxA+mgXTtq8GQV1iteavHhCmcmpCriF3lsdLax61+g==
 {{- end }}


### PR DESCRIPTION
According to https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/tag/v1.6.0-rc.14